### PR TITLE
Since kdcPassword is also used for Ambari it should be added to the model

### DIFF
--- a/src/main/java/veil/hdp/vagrant/generator/service/AbstractFileService.java
+++ b/src/main/java/veil/hdp/vagrant/generator/service/AbstractFileService.java
@@ -85,11 +85,10 @@ public abstract class AbstractFileService implements FileService {
         if (arguments.isKerberosEnabled()) {
             model.put("realmUpper", arguments.getKerberosRealm().toUpperCase());
             model.put("realmLower", arguments.getKerberosRealm().toLowerCase());
-            model.put("kdcAdmin", Constants.KDC_ADMIN);
-            model.put("kdcPassword", Constants.KDC_PASSWORD);
         }
 
-
+        model.put("kdcAdmin", Constants.KDC_ADMIN);
+        model.put("kdcPassword", Constants.KDC_PASSWORD);
 
         Mustache.Lambda logger = (frag, out) -> {
             out.write("echo \" \"\n");


### PR DESCRIPTION
The kdcPassword variable need to be added to the model for templating since it is also used for Ambari